### PR TITLE
kirkstone pr test

### DIFF
--- a/recipes-support/amazon-ssm-agent/amazon-ssm-agent_3.1.1575.0.bb
+++ b/recipes-support/amazon-ssm-agent/amazon-ssm-agent_3.1.1575.0.bb
@@ -6,8 +6,7 @@ LIC_FILES_CHKSUM = " \
 GO_IMPORT = "github.com/aws/amazon-ssm-agent"
 SRC_URI = "git://${GO_IMPORT};branch=mainline;protocol=https"
 
-PV = "3.1.0.0+git${SRCPV}"
-SRCREV = "232b1d9a483b0404530798bf412409d23aecf630"
+SRCREV = "c4414a04a161ed90e141050fb1a8cc7f43835e70"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
-  removed pv variable as it was causing the wrong recipes to be used
- firecracker: remove dynamic-layer
- jailer: prevent network use outside of DL task
- firecracker jailer: panic-abort from workspace
- add new version: greengrass-bin 2.5.6, greengrass-bin-demo 2.5.6, greengrass 1.11.6
- aws-iot-device-sdk-python-v1: fix version from AUTOREV git to 1.5.2
- python3-timeloop, aws-iot-device-sdk-python-v1: check for the correct useage of setuptools3_legacy and setuptools3
- awscli: set branch parameter in SRC_URI
- amazon-ssm-agent: upgrade git -> 3.1.1575.0
