### PR TITLE
[Backport kirkstone] Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 **/.DS_Store
+*aödlfkj


### PR DESCRIPTION
# Description
Backport of #97 to `kirkstone`.