### PR TITLE
aws-iot-securetunneling-localproxy: upgrade git -> new

### DIFF
--- a/recipes-iot/aws-iot-securetunneling-localproxy/aws-iot-securetunneling-localproxy_git.bb
+++ b/recipes-iot/aws-iot-securetunneling-localproxy/aws-iot-securetunneling-localproxy_git.bb
@@ -18,13 +18,14 @@ BRANCH ?= "main"
 
 # nooelint: oelint.file.patchsignedoff
 SRC_URI = "\
-  git://git@github.com/aws-samples/aws-iot-securetunneling-localproxy.git;branch=${BRANCH};protocol=https \
-  file://boost-support-any.patch \
-  file://remove-cxx-standard.patch \
-  file://boost-include-format.patch \
-  file://run-ptest \
-  "
-SRCREV = "af10b9cfca45723559f3bc44e9033521c0f792a4"
+    git://git@github.com/aws-samples/aws-iot-securetunneling-localproxy.git;branch=${BRANCH};protocol=https \
+    file://0001-boost-support-any.patch \
+    file://0002-remove-cxx-standard.patch \
+    file://0003-boost-include-format.patch \
+    file://0004-cmake-version.patch \
+    file://run-ptest \
+    "
+SRCREV = "b9d706f92b64dc003514fa31ae804564fb0af429"
 
 UPSTREAM_CHECK_COMMITS = "1"
 

--- a/recipes-iot/aws-iot-securetunneling-localproxy/files/0001-boost-support-any.patch
+++ b/recipes-iot/aws-iot-securetunneling-localproxy/files/0001-boost-support-any.patch
@@ -1,4 +1,4 @@
-From f10e6fd2675108639990925c1ab3b5e41616329b Mon Sep 17 00:00:00 2001
+From 43dc568150e30bcb8f2304efbadcb36ef145706d Mon Sep 17 00:00:00 2001
 From: Thomas Roos <throos@amazon.de>
 Date: Fri, 10 Mar 2023 12:46:05 +0000
 Subject: [PATCH] aws-iot-securetunneling-localproxy: support any boost version
@@ -9,10 +9,10 @@ Upstream-Status: Denied [Any version that compile should be good, team does only
  1 file changed, 1 insertion(+), 2 deletions(-)
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 79db672..8f16a11 100644
+index aa4e90b..02ac23c 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -83,8 +83,7 @@ endif(BUILD_TESTS)
+@@ -92,8 +92,7 @@ endif(BUILD_TESTS)
  set(Boost_USE_STATIC_LIBS ON)
  set(Boost_USE_DEBUG_RUNTIME OFF)
  #set_property(GLOBAL PROPERTY Boost_USE_MULTITHREADED ON)

--- a/recipes-iot/aws-iot-securetunneling-localproxy/files/0002-remove-cxx-standard.patch
+++ b/recipes-iot/aws-iot-securetunneling-localproxy/files/0002-remove-cxx-standard.patch
@@ -1,4 +1,4 @@
-From a8e8a0c95fb45b9d2f7cffb8fa1701dc934971d0 Mon Sep 17 00:00:00 2001
+From 19a0f6aebdb1a597cb098ce086d000e7f97729c7 Mon Sep 17 00:00:00 2001
 From: Thomas Roos <throos@amazon.de>
 Date: Tue, 9 Jan 2024 14:34:32 +0000
 Subject: [PATCH] aws-iot-securetunneling-localproxy: remove setting of
@@ -9,7 +9,7 @@ Upstream-Status: Submitted [author]
  1 file changed, 1 insertion(+), 5 deletions(-)
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 8f16a11..1048f3b 100644
+index 02ac23c..fe71762 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -1,5 +1,3 @@
@@ -18,7 +18,7 @@ index 8f16a11..1048f3b 100644
  set(AWS_TUNNEL_LOCAL_PROXY_TARGET_NAME localproxy)
  set(AWS_TUNNEL_LOCAL_PROXY_LIB_NAME lproxy)
  project(${AWS_TUNNEL_LOCAL_PROXY_TARGET_NAME} CXX)
-@@ -22,9 +20,7 @@ endif ()
+@@ -31,9 +29,7 @@ endif ()
  ########################################
  # Section : Common Build setttings #
  ########################################

--- a/recipes-iot/aws-iot-securetunneling-localproxy/files/0003-boost-include-format.patch
+++ b/recipes-iot/aws-iot-securetunneling-localproxy/files/0003-boost-include-format.patch
@@ -1,4 +1,4 @@
-From 2a7d283cd1f7882f6d499301087532d138e86b07 Mon Sep 17 00:00:00 2001
+From 9bd80c4a89bf22e0b3d59dfa9e85f8dbed4bbdcc Mon Sep 17 00:00:00 2001
 From: Thomas Roos <throos@amazon.de>
 Date: Mon, 11 Mar 2024 10:35:55 +0000
 Subject: [PATCH] aws-iot-securetunneling-localproxy: boost 1.84 format include
@@ -9,7 +9,7 @@ Upstream-Status: Submitted [author]
  1 file changed, 2 insertions(+), 1 deletion(-)
 
 diff --git a/src/config/ConfigFile.cpp b/src/config/ConfigFile.cpp
-index 105ca10..ce9f17b 100644
+index 2a3205c..6e25a2f 100644
 --- a/src/config/ConfigFile.cpp
 +++ b/src/config/ConfigFile.cpp
 @@ -19,6 +19,7 @@
@@ -20,7 +20,7 @@ index 105ca10..ce9f17b 100644
  #include <boost/property_tree/ini_parser.hpp>
  #include <boost/algorithm/string.hpp>
  #include <boost/lexical_cast.hpp>
-@@ -212,4 +213,4 @@ namespace aws { namespace iot { namespace securedtunneling { namespace config_fi
+@@ -219,4 +220,4 @@ namespace aws { namespace iot { namespace securedtunneling { namespace config_fi
          boost::filesystem::path full_path(boost::filesystem::current_path());
          return (boost::format("%1%/config") % full_path.string()).str();
      }

--- a/recipes-iot/aws-iot-securetunneling-localproxy/files/0004-cmake-version.patch
+++ b/recipes-iot/aws-iot-securetunneling-localproxy/files/0004-cmake-version.patch
@@ -1,0 +1,13 @@
+Upstream-Status: Submitted [https://github.com/aws-samples/aws-iot-securetunneling-localproxy/issues/167]
+
+Index: git/CMakeLists.txt
+===================================================================
+--- git.orig/CMakeLists.txt
++++ git/CMakeLists.txt
+@@ -155,3 +155,6 @@ if(BUILD_TESTS)
+ endif(BUILD_TESTS)
+
+ install(TARGETS ${AWS_TUNNEL_LOCAL_PROXY_TARGET_NAME} DESTINATION "bin")
++
++cmake_minimum_required(VERSION 3.22)
++


### PR DESCRIPTION
Added a patch to set min required cmake version:
https://github.com/aws-samples/aws-iot-securetunneling-localproxy/issues/167